### PR TITLE
Moved XYVector and include local headers as strings

### DIFF
--- a/src/controllers/keyboard.c
+++ b/src/controllers/keyboard.c
@@ -1,4 +1,4 @@
-#include <snake.h>
+#include "../lib/vector.h"
 
 #define CONTROLLER_UP 259
 #define CONTROLLER_DOWN 258

--- a/src/lib/snake.c
+++ b/src/lib/snake.c
@@ -1,28 +1,5 @@
 #include "snake.h"
 
-struct XYVector generateXyVector(int x, int y) {
-    struct XYVector point;
-    point.x = x;
-    point.y = y;
-
-    return(point);
-}
-
-struct XYVector addXyVectors(struct XYVector vector1, struct XYVector vector2) {
-    struct XYVector newXyVector;
-
-    newXyVector.x = vector1.x + vector2.x;
-    newXyVector.y = vector1.y + vector2.y;
-
-    return newXyVector;
-}
-
-int equalXyVectors(struct XYVector vector1, struct XYVector vector2) {
-    if(vector1.x != vector2.x) return 0;
-    if(vector1.y != vector2.y) return 0;
-    return 1;
-}
-
 void freeSnake(struct Snake **snakeHead) {
     struct Snake *currentNode = NULL;
 

--- a/src/lib/snake.h
+++ b/src/lib/snake.h
@@ -2,20 +2,13 @@
 #define SNAKE_H_
 
 #include <stdlib.h>
-
-struct XYVector {
-    int x;
-    int y;
-};
+#include "vector.h"
 
 struct Snake {
     struct XYVector position;
     struct Snake *next;
 };
 
-struct XYVector generateXyVector(int x, int y);
-struct XYVector addXyVectors(struct XYVector vector1, struct XYVector vector2);
-int equalXyVectors(struct XYVector vector1, struct XYVector vector2);
 void freeSnake(struct Snake **snake);
 void feedSnake(struct Snake **snake);
 void moveSnake(struct Snake **snake, struct XYVector vector);

--- a/src/lib/vector.c
+++ b/src/lib/vector.c
@@ -1,0 +1,24 @@
+#include "vector.h"
+
+struct XYVector generateXyVector(int x, int y) {
+    struct XYVector point;
+    point.x = x;
+    point.y = y;
+
+    return(point);
+}
+
+struct XYVector addXyVectors(struct XYVector vector1, struct XYVector vector2) {
+    struct XYVector newXyVector;
+
+    newXyVector.x = vector1.x + vector2.x;
+    newXyVector.y = vector1.y + vector2.y;
+
+    return newXyVector;
+}
+
+int equalXyVectors(struct XYVector vector1, struct XYVector vector2) {
+    if(vector1.x != vector2.x) return 0;
+    if(vector1.y != vector2.y) return 0;
+    return 1;
+}

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -1,0 +1,13 @@
+#ifndef VECTOR_H_
+#define VECTOR_H_
+
+struct XYVector {
+    int x;
+    int y;
+};
+
+struct XYVector generateXyVector(int x, int y);
+struct XYVector addXyVectors(struct XYVector vector1, struct XYVector vector2);
+int equalXyVectors(struct XYVector vector1, struct XYVector vector2);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -5,7 +5,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-#include <snake.h>
+#include "lib/snake.h"
 #include "controllers/keyboard.c"
 
 struct XYVector normalizePlanePoint(struct XYVector point, struct XYVector screenDims) {

--- a/test/generators/snake.c
+++ b/test/generators/snake.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
-#include <snake.h>
-
+#include "../../src/lib/snake.h"
 
 struct Snake * generateSingleNodeSnake(void) {
     struct Snake *snakeHead = NULL;

--- a/test/lib/snake.test.c
+++ b/test/lib/snake.test.c
@@ -1,5 +1,5 @@
 #include <unity.h>
-#include <snake.h>
+#include "../../src/lib/snake.h"
 #include "../generators/snake.c"
 
 void test_lib_snake_freeSnake(void) {


### PR DESCRIPTION
## Overview
It is not clean to have `XYVector` definitions inside `snake.h`/`snake.c`. 
Including local lib headers as `<"LIB">` causes undefined vscode hints.

## Changes
- [x] Move `XYVector` struct and it's methods to its own file.
- [x] Refactor local lib includes from `<"LIB">` to `"path/to/lib"`.