### PR TITLE
Added game screen boundaries 

### DIFF
--- a/src/game/validations.c
+++ b/src/game/validations.c
@@ -1,0 +1,19 @@
+#include "../lib/vector.h"
+
+/**
+ * Validates Snake's XYVector normalized position within 
+ * game boundaries.
+ * 
+ * @param normPos Normalized node position
+ * @param boundaries Game screen boundaries
+ * 
+ * @returns 0 (false) or 1 (true)
+*/
+int validateNodePosition(struct XYVector normPos, struct XYVector boundaries) {
+    if (normPos.x >= boundaries.x) return 0;
+    if (normPos.y >= boundaries.y) return 0;
+    if (normPos.x <= 0) return 0;
+    if (normPos.y <= 0) return 0;
+
+    return 1;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "lib/snake.h"
+#include "game/validations.c"
 #include "controllers/keyboard.c"
 
 struct XYVector normalizePlanePoint(struct XYVector point, struct XYVector screenDims) {
@@ -25,6 +26,8 @@ int main() {
     struct XYVector direction;
     struct XYVector directionTmp;
     struct XYVector currentPos;
+    struct XYVector gameBoundaries;
+    struct XYVector snakeHeadPosNorm;
     int ch;
 
     static const char quitMsg[] = "Press Q to Quit";
@@ -45,14 +48,10 @@ int main() {
     /* Game loop */
     do {
         erase();
-        mvaddstr(LINES-1, (COLS-strlen(quitMsg))/2, quitMsg);
 
-        if(snakeLength(snakeHead) == 10) {
-            sleep(3);
-            endwin();
-            freeSnake(&snakeHead);
-            return 0;
-        }
+        gameBoundaries = generateXyVector(COLS, LINES);
+
+        mvaddstr(LINES-1, (COLS-strlen(quitMsg))/2, quitMsg);
         
         // If a key has been pressed, calculate a direction
         ch = getch();
@@ -67,7 +66,7 @@ int main() {
         snakePtr = snakeHead;
         while(snakePtr != NULL) {
             
-            currentPos = normalizePlanePoint(snakePtr->position, generateXyVector(COLS, LINES));
+            currentPos = normalizePlanePoint(snakePtr->position, gameBoundaries);
             // printw("(%d, %d)", currentPos.x, currentPos.y);
             mvaddch(currentPos.y, currentPos.x, '*');
             // mvprintw(currentPos.y, currentPos.x, "*");
@@ -79,6 +78,12 @@ int main() {
         refresh();
 
         moveSnake(&snakeHead, direction);
+        snakeHeadPosNorm = normalizePlanePoint(snakeHead->position, gameBoundaries);
+        if(!validateNodePosition(snakeHeadPosNorm, gameBoundaries)) {
+            endwin();
+            freeSnake(&snakeHead);
+            return 0;
+        }
     } while(true);
     return 0;
 }

--- a/test/game/validations.test.c
+++ b/test/game/validations.test.c
@@ -1,0 +1,32 @@
+#include <unity.h>
+#include "../../src/lib/vector.h"
+#include "../../src/game/validations.c"
+
+struct XYVector normalizePlanePoint(struct XYVector point, struct XYVector screenDims) {
+    struct XYVector normalizedPoint;
+
+    normalizedPoint.x = (screenDims.x / 2) + point.x;
+    normalizedPoint.y = (screenDims.y / 2) + (point.y * -1);
+
+    return normalizedPoint;
+}
+
+void test_game_validations_validateNodePosition_outbound(void) {
+    struct XYVector boundaries = generateXyVector(10, 10);
+    struct XYVector nodePosition = generateXyVector(6, 0);
+
+    nodePosition = normalizePlanePoint(nodePosition, boundaries);
+
+    TEST_ASSERT_FALSE(validateNodePosition(nodePosition, boundaries));
+    return;
+}
+
+void test_game_validations_validateNodePosition_inbound(void) {
+struct XYVector boundaries = generateXyVector(10, 10);
+    struct XYVector nodePosition = generateXyVector(4, 0);
+
+    nodePosition = normalizePlanePoint(nodePosition, boundaries);
+
+    TEST_ASSERT_TRUE(validateNodePosition(nodePosition, boundaries));
+    return;
+}

--- a/test/lib/snake.test.c
+++ b/test/lib/snake.test.c
@@ -12,48 +12,6 @@ void test_lib_snake_freeSnake(void) {
     return;
 }
 
-void test_lib_snake_generateXyVector(void) {
-    struct XYVector point;
-    int expectedX = 34;
-    int expectedY = -167;
-
-    point = generateXyVector(expectedX, expectedY);
-    TEST_ASSERT_EQUAL_INT(expectedX, point.x);
-    TEST_ASSERT_EQUAL_INT(expectedY, point.y);
-
-    return;
-}
-
-void test_lib_snake_addXyVectors(void) {
-    struct XYVector vector;
-    int expectedX = 34;
-    int expectedY = -167;
-
-    vector = addXyVectors(generateXyVector(expectedX,expectedY), generateXyVector(expectedX,expectedY));
-    TEST_ASSERT_EQUAL_INT(expectedX * 2, vector.x);
-    TEST_ASSERT_EQUAL_INT(expectedY * 2, vector.y);
-
-    return;
-}
-
-void test_lib_snake_equalXyVectors(void) {
-    struct XYVector vector1;
-    struct XYVector vector2;
-    int x = 34;
-    int y = -167;
-
-    // Test true case
-    vector1 = generateXyVector(x, y);
-    vector2 = generateXyVector(x, y);
-    TEST_ASSERT_TRUE(equalXyVectors(vector1, vector2));
-    
-    // Test false case
-    vector1 = generateXyVector(x, y);
-    vector2 = generateXyVector(x-1, y-1);
-    TEST_ASSERT_FALSE(equalXyVectors(vector1, vector2));
-    return;
-}
-
 void test_lib_snake_snakeLength(void) {
     int foodAmt;    // The amount of food to feed the snake
 

--- a/test/lib/vector.test.c
+++ b/test/lib/vector.test.c
@@ -1,0 +1,44 @@
+#include <unity.h>
+#include "../../src/lib/vector.h"
+
+void test_lib_vector_generateXyVector(void) {
+    struct XYVector point;
+    int expectedX = 34;
+    int expectedY = -167;
+
+    point = generateXyVector(expectedX, expectedY);
+    TEST_ASSERT_EQUAL_INT(expectedX, point.x);
+    TEST_ASSERT_EQUAL_INT(expectedY, point.y);
+
+    return;
+}
+
+void test_lib_vector_addXyVectors(void) {
+    struct XYVector vector;
+    int expectedX = 34;
+    int expectedY = -167;
+
+    vector = addXyVectors(generateXyVector(expectedX,expectedY), generateXyVector(expectedX,expectedY));
+    TEST_ASSERT_EQUAL_INT(expectedX * 2, vector.x);
+    TEST_ASSERT_EQUAL_INT(expectedY * 2, vector.y);
+
+    return;
+}
+
+void test_lib_vector_equalXyVectors(void) {
+    struct XYVector vector1;
+    struct XYVector vector2;
+    int x = 34;
+    int y = -167;
+
+    // Test true case
+    vector1 = generateXyVector(x, y);
+    vector2 = generateXyVector(x, y);
+    TEST_ASSERT_TRUE(equalXyVectors(vector1, vector2));
+    
+    // Test false case
+    vector1 = generateXyVector(x, y);
+    vector2 = generateXyVector(x-1, y-1);
+    TEST_ASSERT_FALSE(equalXyVectors(vector1, vector2));
+    return;
+}

--- a/test/main.test.c
+++ b/test/main.test.c
@@ -1,6 +1,8 @@
 #include <unity.h>
-#include "./controllers/keyboard.test.c"
+#include "./lib/vector.test.c"
 #include "./lib/snake.test.c"
+#include "./game/validations.test.c"
+#include "./controllers/keyboard.test.c"
 
 void setUp() {}
 void tearDown() {}
@@ -8,18 +10,24 @@ void tearDown() {}
 int main() {
     UNITY_BEGIN();
     
-    // TESTING src/controller/keyboard.c
-    RUN_TEST(test_controller_keyboard_calculateDirection);
-    
-    // TESTING src/snake/snake.c
+    // TESTING src/lib/vector.c
+    RUN_TEST(test_lib_vector_generateXyVector);
+    RUN_TEST(test_lib_vector_addXyVectors);
+    RUN_TEST(test_lib_vector_equalXyVectors);
+
+    // TESTING src/lib/snake.c
     RUN_TEST(test_lib_snake_freeSnake);
     RUN_TEST(test_lib_snake_snakeLength);
     RUN_TEST(test_lib_snake_feedSnake);
     RUN_TEST(test_lib_snake_moveSnake_nonFed);
     RUN_TEST(test_lib_snake_moveSnake_fed);
-    RUN_TEST(test_lib_snake_generateXyVector);
-    RUN_TEST(test_lib_snake_addXyVectors);
-    RUN_TEST(test_lib_snake_equalXyVectors);
+
+    // TESTING src/controller/keyboard.c
+    RUN_TEST(test_controller_keyboard_calculateDirection);
     
+    // TESTING src/game/validations.c
+    RUN_TEST(test_game_validations_validateNodePosition_outbound);
+    RUN_TEST(test_game_validations_validateNodePosition_inbound);
+
     return UNITY_END();
 }


### PR DESCRIPTION
## Overview
Snake nodes should not be able to go past terminal's boundaries.

## Changes
- [x] Add game boundaries validation method.
- [x] Add unit tests for boundaries validation method.
- [x] Modified main game loop to end the game when boundaries are reached/touched.