### PR TITLE
Chore/clang warnings to errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APP_NAME=snake-cli
 PATH_OUT=build
 
 CC=clang
-CFLAGS=-Wall -Wno-multichar
+CFLAGS=-Wall -Wno-multichar -Werror
 LDFLAGS=-lcurses
 CH_INC=-I src/lib/
 CSRC=src/lib/*.c src/main.c

--- a/src/game/engine.c
+++ b/src/game/engine.c
@@ -63,7 +63,6 @@ void doGame(void) {
     struct XYVector currentPos;
     struct XYVector gameBoundaries;
     struct XYVector snakeHeadPosNorm;
-    struct XYVector snakeTailPosNorm;
     struct XYVector prevSnakeTailPos;
     int snakeLen;
 
@@ -89,7 +88,7 @@ void doGame(void) {
 
 
         mvprintw(0, 0, "");
-        mvprintw(0, 0, "length: %d", snakeLength(snakeHead));
+        mvprintw(0, 0, "length: %d", snakeLen);
         mvprintw(1, 0, "");
         mvprintw(1, 0, "current_snake_tail_pos: (%d, %d)               ", snakeTail->position.x, snakeTail->position.y);
         mvprintw(2, 0, "");


### PR DESCRIPTION
## Changes
- [x] Convert `clang`compiler warnings to errors by adding `-Werror` flag.
- [x] Fix current warnings. 